### PR TITLE
Tie shift key to zoom

### DIFF
--- a/breadcrumbs/src/BreadcrumbApp.js
+++ b/breadcrumbs/src/BreadcrumbApp.js
@@ -276,7 +276,7 @@ export default class BreadcrumbApp extends Component<any, any> {
 
             p.mouseWheel = function(e) {
                 // Handle pinch-to-zoom functionality
-                if (e.ctrlKey) {
+                if (e.ctrlKey || e.shiftKey) {
                     if (e.wheelDelta < 0) {
                         self.scaleDown();
                     } else {

--- a/pointfog/src/PointfogApp.js
+++ b/pointfog/src/PointfogApp.js
@@ -249,7 +249,7 @@ export default class PointfogApp extends Component<any, any> {
 
             p.mouseWheel = function (e) {
                 // Handle pinch-to-zoom functionality
-                if (e.ctrlKey) {
+                if (e.ctrlKey || e.shiftKey) {
                     if (e.wheelDelta < 0) {
                         self.scaleDown();
                     } else {


### PR DESCRIPTION
Add shift+scroll as a zoom option. Improve experience on chromebook, where ctrl+scroll is tied to zooming UI elements as well.