### PR TITLE
Handle id creation better

### DIFF
--- a/breadcrumbs/src/BreadcrumbApp.js
+++ b/breadcrumbs/src/BreadcrumbApp.js
@@ -2,6 +2,7 @@
 
 import React, { Component } from 'react';
 import * as graphlib from "graphlib";
+import uuidv4 from "uuid/v4";
 
 
 import type { P5Type } from "./types/p5Types";
@@ -454,7 +455,7 @@ export default class BreadcrumbApp extends Component<any, any> {
             newNode.created = oldNode.created;
             newNode.namespace = DB.breadcrumbs_name;
             newNode.type = oldNode.type;
-            newNode.id = oldNode.id;
+            newNode.id = oldNode.id || uuidv4();
             newNode.volume = this.volume._id;
             output.setNode(newNode.id, newNode);
         });

--- a/breadcrumbs/src/layers/TraceManager.js
+++ b/breadcrumbs/src/layers/TraceManager.js
@@ -143,7 +143,6 @@ export default class TraceManager {
             let startingSynapseId = this.g.nodes()[0];
             let startingSynapse = this.g.node(startingSynapseId);
             this.g.removeNode(startingSynapseId);
-            startingSynapse.id = startingSynapse.id || uuidv4();
             startingSynapse.protected = true;
             startingSynapse.type = "initial";
             this.g.setNode(startingSynapseId, startingSynapse);
@@ -155,7 +154,6 @@ export default class TraceManager {
             let nodeIds = this.g.nodes();
             nodeIds.forEach(nodeId => {
                 let node = this.g.node(nodeId);
-                node.id = nodeId || uuidv4();
                 node.protected = true;
                 this.g.setNode(nodeId, node);
                 if (node.type === "initial") {
@@ -170,17 +168,14 @@ export default class TraceManager {
         }
     }
 
-    extendGraph(newNodeId: string, newNode: NodeMeta): void {
+    extendGraph(newNode: NodeMeta): void {
         if (this.activeNode) {
-            newNodeId = newNodeId || uuidv4();
-            // Verify that the node IDs line up
-            newNode.id = newNodeId;
-            this.g.setNode(newNodeId, newNode);
+            this.g.setNode(newNode.id, newNode);
 
             // Create an edge from the active node.
             let newEdge = {
                 v: this.activeNode.id,
-                w: newNodeId
+                w: newNode.id
             };
             this.g.setEdge(newEdge);
             this.activeNode = newNode;
@@ -204,7 +199,7 @@ export default class TraceManager {
                 id: newNodeId
             });
 
-            this.extendGraph(newNodeId, newNode);
+            this.extendGraph(newNode);
         }
 
         this.drawHinting = false;


### PR DESCRIPTION
Address recent breadcrumbs issue. Create uuid only on graph conversion from colocard or extension of existing graph by one leaf node.