### PR TITLE
Add default text to artifact report

### DIFF
--- a/breadcrumbs/src/BreadcrumbApp.js
+++ b/breadcrumbs/src/BreadcrumbApp.js
@@ -810,7 +810,7 @@ export default class BreadcrumbApp extends Component<any, any> {
                 <tr
                     key={`artifact_snapshot_title`}
                 >
-                    {`Artifacts in Volume: ${artifactSnapshots.length}`}
+                    {`Images with Tagged Artifacts: ${artifactSnapshots.length}`}
                 </tr>
             );
         }

--- a/pointfog/src/PointfogApp.js
+++ b/pointfog/src/PointfogApp.js
@@ -701,7 +701,7 @@ export default class PointfogApp extends Component<any, any> {
                 <tr
                     key={`artifact_snapshot_title`}
                 >
-                    {`Artifacts in Volume: ${artifactSnapshots.length}`}
+                    {`Images with Tagged Artifacts: ${artifactSnapshots.length}`}
                 </tr>
             );
         }


### PR DESCRIPTION
Current artifact report shows pixel-wide modal if no artifacts are annotated. Add blurb with explanatory text.