### PR TITLE
Use compression for artifact snapshots

### DIFF
--- a/breadcrumbs/src/BreadcrumbApp.js
+++ b/breadcrumbs/src/BreadcrumbApp.js
@@ -743,6 +743,7 @@ export default class BreadcrumbApp extends Component<any, any> {
         let artifactButtonColor = "default";
         let artifactChecklistHTML = [];
         let artifactSnapshots = [];
+        let jpegQuality = 0.5;
 
         if (this.artifactFlag) {
             // this initialization currently must happen in both
@@ -762,7 +763,7 @@ export default class BreadcrumbApp extends Component<any, any> {
                                 this.artifacts[artifact][newZ] = checked;
                                 if (checked === true) {
                                     if (!(newZ in this.artifactImageUrls)) {
-                                        this.artifactImageUrls[newZ] = this.layers.imageManager.p.canvas.toDataURL();
+                                        this.artifactImageUrls[newZ] = this.layers.imageManager.p.canvas.toDataURL("image/jpeg", jpegQuality);
                                     }
                                 } else {
                                     let noneFlag = true;

--- a/pointfog/src/PointfogApp.js
+++ b/pointfog/src/PointfogApp.js
@@ -634,6 +634,7 @@ export default class PointfogApp extends Component<any, any> {
         let artifactButtonColor = "default";
         let artifactChecklistHTML = [];
         let artifactSnapshots = [];
+        let jpegQuality = 0.5;
 
         if (this.artifactFlag) {
             // this initialization currently must happen in both
@@ -653,7 +654,7 @@ export default class PointfogApp extends Component<any, any> {
                                 this.artifacts[artifact][newZ] = checked;
                                 if (checked === true) {
                                     if (!(newZ in this.artifactImageUrls)) {
-                                        this.artifactImageUrls[newZ] = this.layers.imageManager.p.canvas.toDataURL();
+                                        this.artifactImageUrls[newZ] = this.layers.imageManager.p.canvas.toDataURL("image/jpeg", jpegQuality);
                                     }
                                 } else {
                                     let noneFlag = true;


### PR DESCRIPTION
#174 

When artifacts are tagged, a screenshot of the slice is taken. Enough of these screenshots will crash the browser, so we update to using jpeg-compression to allow for many more tagged slices to appear in the report.