### PR TITLE
Add more context to Macchiato where available

### DIFF
--- a/macchiato/src/MacchiatoApp.js
+++ b/macchiato/src/MacchiatoApp.js
@@ -127,9 +127,6 @@ export default class MacchiatoApp extends Component<any, any> {
                     // Tighten the crop around the node:
                     let node = self.node;
 
-                    console.log(self.volume.bounds);
-                    console.log(coordinateFrameBounds);
-
                     // Use JSON to deep copy
                     let lowerLimits = JSON.parse(
                         JSON.stringify([


### PR DESCRIPTION
Expand window for context to include full data available from coordinate frame, even if it falls outside of the volume.