### PR TITLE
Use X key to delete

### DIFF
--- a/breadcrumbs/src/BreadcrumbApp.js
+++ b/breadcrumbs/src/BreadcrumbApp.js
@@ -241,6 +241,7 @@ export default class BreadcrumbApp extends Component<any, any> {
                 const oKey = 79;
                 const qKey = 81;
                 const tKey = 84;
+                const xKey = 88;
                 const upArrowKey = 38;
                 const downArrowKey = 40;
                 const leftArrowKey = 37;
@@ -302,9 +303,10 @@ export default class BreadcrumbApp extends Component<any, any> {
                         self.popBookmark();
                         break;
                     // deletion
+                    case xKey:
                     case backspaceKey:
                         self.deleteActiveNode();
-                        break;
+                        return false;
                     default:
                         break;
                 }

--- a/pointfog/src/PointfogApp.js
+++ b/pointfog/src/PointfogApp.js
@@ -216,6 +216,7 @@ export default class PointfogApp extends Component<any, any> {
                 const sKey = 83;
                 const tKey = 84;
                 const wKey = 87;
+                const xKey = 88;
                 const upArrowKey = 38;
                 const downArrowKey = 40;
                 const leftArrowKey = 37;
@@ -277,10 +278,10 @@ export default class PointfogApp extends Component<any, any> {
                     case atSignKey:
                         self.popBookmark();
                         break;
-                    // deletion
+                    case xKey:
                     case backspaceKey:
                         self.deleteActiveNode();
-                        break;
+                        return false;
                     default:
                         break;
                 }


### PR DESCRIPTION
This resolves some browsers using the Backspace button as a Page-Back feature (as well as deleting a node) and also adds support for the <kbd>X</kbd> key for node deletion in `Pointfog` and `Breadcrumbs`.